### PR TITLE
Made phantoms immune to insomnia.

### DIFF
--- a/flexzcraft/data/flexzcraft_origins/origins/phantom.json
+++ b/flexzcraft/data/flexzcraft_origins/origins/phantom.json
@@ -9,7 +9,8 @@
 		"flexzcraft_origins:burn_in_daylight",
 		"flexzcraft_origins:hunger_over_time",
 		"flexzcraft_origins:fragile",
-		"flexzcraft_origins:phantomize_overlay"
+		"flexzcraft_origins:phantomize_overlay",
+		"flexzcraft_origins:passive_phantoms"
 	],
 	"icon": {
 		"item": "minecraft:phantom_membrane"

--- a/flexzcraft/data/flexzcraft_origins/powers/passive_phantoms.json
+++ b/flexzcraft/data/flexzcraft_origins/powers/passive_phantoms.json
@@ -1,0 +1,10 @@
+{
+    "type": "origins:modify_insomnia_ticks",
+    "name": "Dreamless Being",
+    "description": "You do not suffer the effects of insomnia.",
+
+    "modifier": {
+        "operation": "set_total",
+        "value": 0
+    }
+}


### PR DESCRIPTION
Phantoms no longer suffer the effects of insomnia.

DEVELOPER NOTE: This is a temporary measure. When the modpack is updated in summer, if Pehkui is installed, I really recommend changing this power to set your visibility scale to 0 for phantoms. This would essentially make them passive to you.